### PR TITLE
Make JsonSchemaProvider pick from defined enums if type has been set

### DIFF
--- a/src/JsonSchemaProvider.php
+++ b/src/JsonSchemaProvider.php
@@ -16,8 +16,12 @@ class JsonSchemaProvider
 
     public static function jsonSchema(array $schema)
     {
-        if (!isset($schema['type']) && !empty($schema['enum'])) {
+        if (!empty($schema['enum'])) {
             return array_rand(array_flip($schema['enum']));
+        }
+
+        if (!isset($schema['type'])) {
+            return null;
         }
 
         switch ($schema['type']) {

--- a/tests/JsonSchemaProviderTest.php
+++ b/tests/JsonSchemaProviderTest.php
@@ -48,4 +48,16 @@ class JsonSchemaProviderTest extends TestCase
             yield [$path => file_get_contents($path)];
         }
     }
+
+    public function testFakeEnumEntriesArePickedFromDefinedEnumSet(): void
+    {
+        $json = file_get_contents(__DIR__.'/schema/enum.json');
+        $data = $this->faker->jsonSchemaContent($json);
+        $schema = json_decode($json);
+
+        $definedEnumSet = $schema->properties->enumProperty->enum;
+        $fakeEnumEntry = $data->enumProperty;
+
+        $this->assertArrayHasKey($fakeEnumEntry, array_flip($definedEnumSet));
+    }
 }

--- a/tests/schema/enum.json
+++ b/tests/schema/enum.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "properties": {
+        "enumProperty": {
+            "type": "string",
+            "enum": [
+                "US",
+                "CA",
+                "GB"
+            ]
+        }
+    },
+    "required": ["enumProperty"]
+}


### PR DESCRIPTION

## Description

This PR removes the check whether the type keyword has been set from the check for applicable enum values in 
JsonSchemaProvider:19.

## Motivation and context

The current implementation only picks enums from the defined entries in the enum array if the type keyword has not 
been set. If the type keyword has been set it generates a random value according to the type and ignores the defined
set of expected enums. According to JSON-Schema https://json-schema.org/understanding-json-schema/reference/generic.html 
the type is optional and should be used if possible.


## How has this been tested?

I've added a test which compares the generated result with the set of expected enums in the schema. The test will pass
if the generated result is part of the defined set of enums.

The tests where run using PHPUnit 8.2.4 
PHP Language Level 7.1
CLI Interpreter 7.2

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
