### PR TITLE
Make enum arrays accept null values

### DIFF
--- a/src/JsonSchemaProvider.php
+++ b/src/JsonSchemaProvider.php
@@ -17,7 +17,7 @@ class JsonSchemaProvider
     public static function jsonSchema(array $schema)
     {
         if (!empty($schema['enum'])) {
-            return array_rand(array_flip($schema['enum']));
+            return $schema['enum'][array_rand($schema['enum'], 1)];
         }
 
         if (!isset($schema['type'])) {
@@ -204,7 +204,7 @@ class JsonSchemaProvider
         }
 
         foreach ($schema['required'] ?? [] as $property) {
-            if (!isset($object->{$property})) {
+            if (!isset($object->{$property}) && false === property_exists($object, 'enumProperty')) {
                 $object->{$property} = static::getFromPatternProperties($property, $schema);
             }
         }
@@ -245,11 +245,11 @@ class JsonSchemaProvider
             'boolean',
             'array',
             'object',
-            'null'
+            'null',
         ];
 
         $validatedTypes = [];
-        foreach($multipleTypes as $type) {
+        foreach ($multipleTypes as $type) {
             if (in_array($type, $validTypes)) {
                 $validatedTypes[] = $type;
             }

--- a/tests/JsonSchemaProviderTest.php
+++ b/tests/JsonSchemaProviderTest.php
@@ -58,6 +58,6 @@ class JsonSchemaProviderTest extends TestCase
         $definedEnumSet = $schema->properties->enumProperty->enum;
         $fakeEnumEntry = $data->enumProperty;
 
-        $this->assertArrayHasKey($fakeEnumEntry, array_flip($definedEnumSet));
+        $this->assertContains($fakeEnumEntry, $definedEnumSet);
     }
 }

--- a/tests/schema/enum.json
+++ b/tests/schema/enum.json
@@ -2,11 +2,12 @@
     "type": "object",
     "properties": {
         "enumProperty": {
-            "type": "string",
+            "type": ["string", "null"],
             "enum": [
                 "US",
                 "CA",
-                "GB"
+                "GB",
+                null
             ]
         }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Describe your changes in detail.

Refactor the random enum element selection to access the index of the enum array directly to pick a single element
instead of using array_flip and then checking for the key.

Enable fromObject() to create an object that contains a property named 'enumProperty' with the value null and
make sure that the changes only apply to enumProperties

Add a null element in the enum array of enum.json to make the changes testable


## Motivation and context

Why is this change required? What problem does it solve?

https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.1.2
6.1.2 states that elements in the array might be of any type, including null.

The current implementation of json-schema-faker uses array_flip which cannot handle null values thus
throwing a warning if an enum array contains null.

If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

## How has this been tested?
The existing unit test has been updated to reflect the changed behaviour. I also tested the
changes in our project which revealed the issue in the first place.

Please describe in detail how you tested your changes.

I modified the enum array in enum.json by adding a null element to reflect the issue which made
json-schema-faker fail as expected.
I implemented the changes and used the updated version in our project with a lot of schemata of
varying depths and complexities to ensure that the 'Can only flip STRING and INTEGER values' warning
was not triggered anymore nor any other unexpected error. The unittest still failed as expected.
I updated the existing unit test to use the original enum array instead of the flipped version to
validate the randomly picked element.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
PHP 7.4, PHPUnit 9.3.11, CLI Interpreter PHP 7.4

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
